### PR TITLE
Disable iOS Safari detection of phone numbers

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="Mainly Active provides fitness training and youth sports coaching in the Bradford, West Yorkshire area, specialising in circuit classes and rugby training.">
     <meta name="author" content="Margaret Maude">
+    <meta name="format-detection" content="telephone=no">
 
     <title>Mainly Active — PPA cover, rugby clubs, sport days, after school clubs and circuit classes in West Yorkshire</title>
 


### PR DESCRIPTION
The feature may be considered useful, but makes the white telephone
number text blue which is out of place. Alternative fixes are via CSS
but this is a simple fix for the time being.